### PR TITLE
commenting out debug statement

### DIFF
--- a/clouds_mod.f90
+++ b/clouds_mod.f90
@@ -286,7 +286,7 @@ contains
                 end do ! miewave loop
              end if ! size if
              !write (1,*) scat_cloud(ilayer,loc1,icloud)
-             write (1,*) 'ext_cloud ',ilayer, ' = ', ext_cloud(ilayer,loc1,icloud)
+             !write (1,*) 'ext_cloud ',ilayer, ' = ', ext_cloud(ilayer,loc1,icloud)
              !write (1,*) cqs_cloud(ilayer,loc1,icloud)
              
           end if


### PR DESCRIPTION
This debug statement, uncommented as of a January 12 commit 818b25e, could potentially run at high frequency in a Fortran hot loop. Since the open/close log pair in marv.f90 are commented out, it's likely being written implicitly to a file like fort.1. Depending on how often this subroutine runs, this could be taking up a nontrivial amount of runtime, causing some disk I/O contention, and leading to a potentially large file accumulating on the cluster needlessly.